### PR TITLE
Remove unused variable

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import {Chart} from 'chart.js';
 import {requestAnimFrame, getStyle} from 'chart.js/helpers';
 
 var STUB_KEY = '$chartjs_deferred';


### PR DESCRIPTION
Fix the lint error I introduced by forgetting to remove the chart variable that is no longer used since plugin is not self registering anymore